### PR TITLE
Fix too long lines

### DIFF
--- a/config/laminas-developer-tools.local.php.dist
+++ b/config/laminas-developer-tools.local.php.dist
@@ -55,8 +55,8 @@ return [
 
             /**
              * Contains a list with all collector the profiler should run. Laminas Developer Tools ships with
-             * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you wish to
-             * disable a default collector, simply set the value to null or false.
+             * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you
+             * wish to disable a default collector, simply set the value to null or false.
              *
              * Example: 'collectors' => array('db' => null)
              * Expects: array
@@ -75,8 +75,8 @@ return [
             'enabled' => true,
 
             /**
-             * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with 'time'
-             * and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
+             * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with
+             * 'time' and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
              *
              * Example: 'collectors' => array('memory' => null)
              * Expects: array
@@ -84,8 +84,8 @@ return [
             'collectors' => [],
 
             /**
-             * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to all
-             * events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
+             * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to
+             * all events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
              * false.
              *
              * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')

--- a/src/Module.php
+++ b/src/Module.php
@@ -166,7 +166,8 @@ class Module implements
                 'ZendDeveloperTools\StorageListener' => 'Laminas\DeveloperTools\StorageListener',
                 \ZendDeveloperTools\Listener\ToolbarListener::class => Listener\ToolbarListener::class,
                 \ZendDeveloperTools\Listener\ProfilerListener::class => Listener\ProfilerListener::class,
-                \ZendDeveloperTools\Listener\EventLoggingListenerAggregate::class => Listener\EventLoggingListenerAggregate::class,
+                \ZendDeveloperTools\Listener\EventLoggingListenerAggregate::class =>
+                    Listener\EventLoggingListenerAggregate::class,
                 'ZendDeveloperTools\DbCollector' => 'Laminas\DeveloperTools\DbCollector',
             ],
             'invokables' => [


### PR DESCRIPTION
After the rewrite as Laminas Project package (commit 0db346ee92edde182f838109bb2815170c6df1f9), some code lines became longer, in some cases exceeding the 120 characters limit. This commit rearranges those lines in order to fit them within the limit.