### PR TITLE
escape of \\ in toolbar content, which create a JS Exception

### DIFF
--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -128,7 +128,7 @@ class ToolbarListener implements ListenerAggregateInterface
         $toolbarJs->setTemplate('laminas-developer-tools/toolbar/script');
         $script      = $this->renderer->render($toolbarJs);
 
-        $toolbar  = str_replace('$', '\$', $toolbar);
+        $toolbar  = str_replace(['$', '\\\\'], ['\$', '\\\\\\'], $toolbar);
         $injected = preg_replace(
             '/<\/body>(?![\s\S]*<\/body>)/i',
             $toolbar . $script . "\n</body>",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

With the last migration to symfony/var-dumper we get now following error

```
Uncaught SyntaxError: Invalid regular expression: /([.*+?^${}()|\[\]\/\])/g, idRx = /\bsf-dump-\d+-ref[012]\w+\b/: Range out of order in character class
```

Because the Escaper change `/([.*+?^${}()|\[\]\/\\])/g` to `/([.*+?^${}()|\[\]\/\])/g`

So the Escaper create a invalid regex, with this fix, the escaper handle it correctly.