### PR TITLE
Fixes #1 : Toolbar should be displayed even without <head> in HTML5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Fixed
 
 - [laminas/laminas-developer-tools#34](https://github.com/laminas/laminas-developer-tools/pull/34) Fix various parameters and returns docblocks.
+- [laminas/laminas-developer-tools#31](https://github.com/laminas/laminas-developer-tools/pull/31) Fixes #1 : Toolbar should be displayed even without `<head>` in HTML5.
 
 ## 2.0.2 - 2020-03-29
 

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -135,7 +135,8 @@ class ToolbarListener implements ListenerAggregateInterface
             $response->getBody(),
             1
         );
-        $injected = preg_replace('/<\/body>/i', $style . "\n</body>", $injected, 1);
+        $prepend = preg_match('/<\/head>/i', $injected) ? 'head' : 'body';
+        $injected = preg_replace('/<\/' . $prepend . '>/i', $style . "\n</$prepend>", $injected, 1);
 
         $response->setContent($injected);
     }

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -135,7 +135,7 @@ class ToolbarListener implements ListenerAggregateInterface
             $response->getBody(),
             1
         );
-        $injected = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
+        $injected = preg_replace('/<\/body>/i', $style . "\n</body>", $injected, 1);
 
         $response->setContent($injected);
     }

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -145,9 +145,9 @@ class ToolbarListener implements ListenerAggregateInterface
 
             $injected = preg_replace('/<\/' . $prepend . '>/i', $style . "\n</$prepend>", $injected, 1);
         } else {
-            if (stripos($body, '<!doctype html>') === 0) {
-                $injected = preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $body, 1);
-            }
+            $injected = stripos($body, '<!doctype html>') === 0
+                ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $body, 1)
+                : $body;
         }
 
         $response->setContent($injected);

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -146,7 +146,9 @@ class ToolbarListener implements ListenerAggregateInterface
             $injected = preg_replace('/<\/' . $prepend . '>/i', $style . "\n</$prepend>", $injected, 1);
         } else {
             $injected = stripos($body, '<!doctype html>') === 0
-                ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $body, 1)
+                ? (stripos($body, '</html>') !== false
+                    ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $body, 1)
+                    : '<!doctype html>' . $body . $style. $toolbar . $script)
                 : $body;
         }
 

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -131,6 +131,8 @@ class ToolbarListener implements ListenerAggregateInterface
         $toolbar  = str_replace(['$', '\\\\'], ['\$', '\\\\\\'], $toolbar);
 
         $content = $response->getBody();
+        $isHTML5 = stripos($content, '<!doctype html>') === 0;
+
         if (preg_match('/<\/body>(?![\s\S]*<\/body>)/i', $content)) {
             $injected = preg_replace(
                 '/<\/body>(?![\s\S]*<\/body>)/i',
@@ -139,13 +141,13 @@ class ToolbarListener implements ListenerAggregateInterface
                 1
             );
 
-            $prepend = stripos($content, '<!doctype html>') === 0
+            $prepend = $isHTML5
                 ? (preg_match('/<\/head>/i', $injected) ? 'head' : 'body')
                 : 'body';
 
             $injected = preg_replace('/<\/' . $prepend . '>/i', $style . "\n</$prepend>", $injected, 1);
         } else {
-            $injected = stripos($content, '<!doctype html>') === 0
+            $injected = $isHTML5
                 ? (stripos($content, '</html>') !== false
                     ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $content, 1)
                     : '<!doctype html>' . $content . $style. $toolbar . $script)

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -130,26 +130,26 @@ class ToolbarListener implements ListenerAggregateInterface
 
         $toolbar  = str_replace(['$', '\\\\'], ['\$', '\\\\\\'], $toolbar);
 
-        $body = $response->getBody();
-        if (preg_match('/<\/body>(?![\s\S]*<\/body>)/i', $body)) {
+        $content = $response->getBody();
+        if (preg_match('/<\/body>(?![\s\S]*<\/body>)/i', $content)) {
             $injected = preg_replace(
                 '/<\/body>(?![\s\S]*<\/body>)/i',
                 $toolbar . $script . "\n</body>",
-                $body,
+                $content,
                 1
             );
 
-            $prepend = stripos($body, '<!doctype html>') === 0
+            $prepend = stripos($content, '<!doctype html>') === 0
                 ? (preg_match('/<\/head>/i', $injected) ? 'head' : 'body')
                 : 'body';
 
             $injected = preg_replace('/<\/' . $prepend . '>/i', $style . "\n</$prepend>", $injected, 1);
         } else {
-            $injected = stripos($body, '<!doctype html>') === 0
-                ? (stripos($body, '</html>') !== false
-                    ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $body, 1)
-                    : '<!doctype html>' . $body . $style. $toolbar . $script)
-                : $body;
+            $injected = stripos($content, '<!doctype html>') === 0
+                ? (stripos($content, '</html>') !== false
+                    ? preg_replace('/<\/html>/i', $style . $toolbar . $script . "\n</html>", $content, 1)
+                    : '<!doctype html>' . $content . $style. $toolbar . $script)
+                : $content;
         }
 
         $response->setContent($injected);

--- a/test/Listener/ToolbarListenerTest.php
+++ b/test/Listener/ToolbarListenerTest.php
@@ -12,14 +12,13 @@ use Laminas\DeveloperTools\Listener\ToolbarListener;
 use Laminas\DeveloperTools\Options;
 use Laminas\DeveloperTools\ProfilerEvent;
 use Laminas\DeveloperTools\Report;
-use Laminas\View\Renderer\PhpRenderer;
-use PHPUnit\Framework\TestCase;
+use Laminas\Http\PhpEnvironment\Request;
+use Laminas\Http\PhpEnvironment\Response;
+use Laminas\ModuleManager\ModuleManager;
 use Laminas\Mvc\Application;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Http\PhpEnvironment\Response;
-use Laminas\Http\PhpEnvironment\Request;
-use Laminas\Http\Headers;
-use Laminas\ModuleManager\ModuleManager;
+use Laminas\View\Renderer\PhpRenderer;
+use PHPUnit\Framework\TestCase;
 
 class ToolbarListenerTest extends TestCase
 {

--- a/test/Listener/ToolbarListenerTest.php
+++ b/test/Listener/ToolbarListenerTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 
 class ToolbarListenerTest extends TestCase
 {
-    public function provideHTMLBody()
+    public function provideHTMLBodyWithInjectedFlag()
     {
         return [
             'not HTML5 has head and body' => ['<html><head></head><body></body></html>', true],
@@ -35,9 +35,9 @@ class ToolbarListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideHTMLBody
+     * @dataProvider provideHTMLBodyWithInjectedFlag
      */
-    public function testOnCollected($htmlBody, $isInjected)
+    public function testOnCollected($htmlBody, $injected)
     {
         $viewRenderer = $this->createMock(PhpRenderer::class);
         $viewRenderer->expects($this->any())
@@ -89,7 +89,7 @@ class ToolbarListenerTest extends TestCase
         $listener = new ToolbarListener($viewRenderer, $option);
         $listener->onCollected($profilerEvent);
 
-        if ($isInjected) {
+        if ($injected) {
             $this->assertRegExp('/script/', $response->getBody());
         }
     }

--- a/test/Listener/ToolbarListenerTest.php
+++ b/test/Listener/ToolbarListenerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-developer-tools for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-developer-tools/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-developer-tools/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\DeveloperTools\Listener;
+
+use Laminas\DeveloperTools\Listener\ToolbarListener;
+use Laminas\DeveloperTools\Options;
+use Laminas\DeveloperTools\ProfilerEvent;
+use Laminas\DeveloperTools\Report;
+use Laminas\View\Renderer\PhpRenderer;
+use PHPUnit\Framework\TestCase;
+use Laminas\Mvc\Application;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Http\PhpEnvironment\Response;
+use Laminas\Http\PhpEnvironment\Request;
+use Laminas\Http\Headers;
+use Laminas\ModuleManager\ModuleManager;
+
+class ToolbarListenerTest extends TestCase
+{
+    public function testOnCollected()
+    {
+        $viewRenderer = $this->createMock(PhpRenderer::class);
+        $profilerEvent = $this->createMock(ProfilerEvent::class);
+        $application = $this->createMock(Application::class);
+        $request = $this->createMock(Request::class);
+        $application->expects($this->once())
+                    ->method('getRequest')
+                    ->willReturn($request);
+
+        $response = $this->createMock(Response::class);
+        $headers = $this->createMock(Headers::class);
+        $response->expects($this->once())
+                 ->method('getHeaders')
+                 ->willReturn($headers);
+        $application->expects($this->any())
+                    ->method('getResponse')
+                    ->willReturn($response);
+
+        $serviceManager = $this->createMock(ServiceManager::class);
+        $application->expects($this->any())
+            ->method('getServiceManager')
+            ->willReturn($serviceManager);
+        $moduleManager = $this->createMock(ModuleManager::class);
+        $moduleManager->expects($this->once())
+                        ->method('getLoadedModules')
+                        ->willReturn([]);
+
+        $serviceManager->expects($this->once())
+                       ->method('get')
+                       ->with('ModuleManager')
+                       ->willReturn($moduleManager);
+
+        $profilerEvent
+            ->expects($this->any())
+            ->method('getApplication')
+            ->willReturn($application);
+
+        $profilerEvent
+            ->expects($this->once())
+            ->method('getReport')
+            ->willReturn(new Report());
+
+        $option = $this->createMock(Options::class);
+        $option->expects($this->once())
+               ->method('getToolbarEntries')
+               ->willReturn([]);
+
+        $listener = new ToolbarListener($viewRenderer, $option);
+        $listener->onCollected($profilerEvent);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Fixes #1 : Toolbar should be displayed even without <head> in HTML5

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
