### PR TITLE
Improve PHPDoc return- and paramter-types

### DIFF
--- a/src/Collector/DbCollector.php
+++ b/src/Collector/DbCollector.php
@@ -99,7 +99,7 @@ class DbCollector implements CollectorInterface, AutoHideInterface, Serializable
      * You can use the constants in the Profiler class to specify
      * what kind of queries you want to get, e.g. Profiler::INSERT.
      *
-     * @param  integer $mode
+     * @param  integer|null $mode
      * @return self
      */
     public function getQueryCount($mode = null)
@@ -113,7 +113,7 @@ class DbCollector implements CollectorInterface, AutoHideInterface, Serializable
      * You can use the constants in the Profiler class to specify
      * what kind of queries you want to get, e.g. Profiler::INSERT.
      *
-     * @param  integer $mode
+     * @param  integer|null $mode
      * @return float|integer
      */
     public function getQueryTime($mode = null)

--- a/src/Collector/RequestCollector.php
+++ b/src/Collector/RequestCollector.php
@@ -155,7 +155,7 @@ class RequestCollector extends AbstractCollector
     /**
      * Returns the controller and action name if possible, otherwise N/A.
      *
-     * @param bool $short
+     * @param bool|null $short
      *            Removes the namespace.
      * @return string
      */

--- a/src/EventLogging/EventContextInterface.php
+++ b/src/EventLogging/EventContextInterface.php
@@ -20,14 +20,15 @@ interface EventContextInterface
     /**
      * Sets the event.
      *
-     * @return null
+     * @param EventInterface $event
+     * @return void
      */
     public function setEvent(EventInterface $event);
 
     /**
      * Collector Priority.
      *
-     * @return Event
+     * @return EventInterface
      */
     public function getEvent();
 }

--- a/src/EventLogging/EventContextProvider.php
+++ b/src/EventLogging/EventContextProvider.php
@@ -30,8 +30,8 @@ class EventContextProvider implements EventContextInterface
     private $debugBacktrace = [];
 
     /**
-     * @param EventInterface $event (Optional) The event to provide context to. The event must be set either here or
-     * with {@see setEvent()} before any other methods can be used.
+     * @param EventInterface|null $event (Optional) The event to provide context to.
+     * The event must be set either here or with {@see setEvent()} before any other methods can be used.
      */
     public function __construct(EventInterface $event = null)
     {
@@ -42,8 +42,8 @@ class EventContextProvider implements EventContextInterface
 
     /**
      * @see \Laminas\DeveloperTools\EventLogging\EventContextInterface::setEvent()
-     * @param  Event $event The event to add context to.
-     * @return null
+     * @param  EventInterface $event The event to add context to.
+     * @return void
      */
     public function setEvent(EventInterface $event)
     {
@@ -52,7 +52,7 @@ class EventContextProvider implements EventContextInterface
 
     /**
      * @see \Laminas\DeveloperTools\EventLogging\EventContextInterface::getEvent()
-     * @return Event
+     * @return EventInterface
      */
     public function getEvent()
     {
@@ -82,7 +82,7 @@ class EventContextProvider implements EventContextInterface
      * Determines a string label to represent an event target.
      *
      * @param mixed $target
-     * @return String
+     * @return string
      */
     private function getEventTargetAsString($target)
     {
@@ -105,7 +105,7 @@ class EventContextProvider implements EventContextInterface
      * Returns the debug_backtrace() for this object with two levels removed so that array starts where this
      * class method was called.
      *
-     * @return string
+     * @return array
      */
     private function getDebugBacktrace()
     {

--- a/src/Listener/EventLoggingListenerAggregate.php
+++ b/src/Listener/EventLoggingListenerAggregate.php
@@ -13,6 +13,7 @@ use Laminas\DeveloperTools\Collector\EventCollectorInterface;
 use Laminas\DeveloperTools\Profiler;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 
 /**
  * Listens to defined events to allow event-level collection of statistics.
@@ -28,7 +29,7 @@ class EventLoggingListenerAggregate
     protected $collectors;
 
     /**
-     * @var The event identifiers to collect
+     * @var string[] The event identifiers to collect
      */
     protected $identifiers;
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -49,7 +49,7 @@ class Module implements
     /**
      * loadModulesPost callback
      *
-     * @param  $event
+     * @param EventInterface $event
      */
     public function onLoadModulesPost($event)
     {

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -123,7 +123,7 @@ class Profiler implements EventManagerAwareInterface
     /**
      * Returns the profiler event object.
      *
-     * @return self
+     * @return ProfilerEvent
      */
     public function getEvent()
     {

--- a/src/Report.php
+++ b/src/Report.php
@@ -21,7 +21,7 @@ class Report implements ReportInterface
     protected $uri;
 
     /**
-     * @var integer
+     * @var \DateTime
      */
     protected $time;
 
@@ -175,6 +175,8 @@ class Report implements ReportInterface
         if (isset($this->collectors[$name])) {
             return $this->collectors[$name];
         }
+
+        return null;
     }
 
     /**
@@ -211,6 +213,8 @@ class Report implements ReportInterface
     public function addCollector(Collector\CollectorInterface $collector)
     {
         $this->collectors[$collector->getName()] = $collector;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Fix some annotations (parameters & return types)

Split from #33 
