### PR TITLE
Remove PHP 8.1 deprecated warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
-.phpunit.result.cache
+/.phpunit.result.cache

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -2,11 +2,13 @@
 
 namespace Laminas\DeveloperTools\Collector;
 
+use Serializable;
+
 /**
  * Serializable Collector base class.
  *
  */
-abstract class AbstractCollector implements CollectorInterface, \Serializable
+abstract class AbstractCollector implements CollectorInterface, Serializable
 {
     /**
      * Collected Data
@@ -15,19 +17,31 @@ abstract class AbstractCollector implements CollectorInterface, \Serializable
      */
     protected $data;
 
-    /**
-     * @see \Serializable
-     */
-    public function serialize()
+    public function __serialize()
     {
         return serialize($this->data);
     }
 
     /**
-     * @see \Serializable
+     * @see Serializable
+     * @deprecated
+     */
+    public function serialize()
+    {
+        return $this->__serialize();
+    }
+
+    public function __unserialize($data)
+    {
+        $this->data = unserialize($data);
+    }
+
+    /**
+     * @see Serializable
+     * @deprecated
      */
     public function unserialize($data)
     {
-        $this->data = unserialize($data);
+        $this->__unserialize($data);
     }
 }

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -23,8 +23,8 @@ abstract class AbstractCollector implements CollectorInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function serialize()
     {
@@ -37,8 +37,8 @@ abstract class AbstractCollector implements CollectorInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function unserialize($data)
     {

--- a/src/Collector/ConfigCollector.php
+++ b/src/Collector/ConfigCollector.php
@@ -85,8 +85,8 @@ class ConfigCollector implements CollectorInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function serialize()
     {
@@ -101,8 +101,8 @@ class ConfigCollector implements CollectorInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function unserialize($serialized)
     {

--- a/src/Collector/ConfigCollector.php
+++ b/src/Collector/ConfigCollector.php
@@ -79,22 +79,34 @@ class ConfigCollector implements CollectorInterface, Serializable
         return isset($this->applicationConfig) ? $this->unserializeArray($this->applicationConfig) : null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function serialize()
+    public function __serialize()
     {
         return serialize(['config' => $this->config, 'applicationConfig' => $this->applicationConfig]);
     }
 
     /**
-     * {@inheritDoc}
+     * @see Serializable
+     * @deprecated
      */
-    public function unserialize($serialized)
+    public function serialize()
+    {
+        return $this->__serialize();
+    }
+
+    public function __unserialize($serialized)
     {
         $data                    = unserialize($serialized);
         $this->config            = $data['config'];
         $this->applicationConfig = $data['applicationConfig'];
+    }
+
+    /**
+     * @see Serializable
+     * @deprecated
+     */
+    public function unserialize($serialized)
+    {
+        $this->__unserialize($serialized);
     }
 
     /**

--- a/src/Collector/DbCollector.php
+++ b/src/Collector/DbCollector.php
@@ -127,8 +127,8 @@ class DbCollector implements CollectorInterface, AutoHideInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function serialize()
     {
@@ -141,8 +141,8 @@ class DbCollector implements CollectorInterface, AutoHideInterface, Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function unserialize($profiler)
     {

--- a/src/Collector/DbCollector.php
+++ b/src/Collector/DbCollector.php
@@ -121,19 +121,31 @@ class DbCollector implements CollectorInterface, AutoHideInterface, Serializable
         return $time;
     }
 
-    /**
-     * @see Serializable
-     */
-    public function serialize()
+    public function __serialize()
     {
         return serialize($this->profiler);
     }
 
     /**
      * @see Serializable
+     * @deprecated
+     */
+    public function serialize()
+    {
+        return $this->__serialize();
+    }
+
+    public function __unserialize($profiler)
+    {
+        $this->profiler = unserialize($profiler);
+    }
+
+    /**
+     * @see Serializable
+     * @deprecated
      */
     public function unserialize($profiler)
     {
-        $this->profiler = unserialize($profiler);
+        $this->__unserialize($profiler);
     }
 }

--- a/src/Exception/SerializableException.php
+++ b/src/Exception/SerializableException.php
@@ -198,8 +198,8 @@ class SerializableException implements Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function serialize()
     {
@@ -212,8 +212,8 @@ class SerializableException implements Serializable
     }
 
     /**
-     * @see Serializable
-     * @deprecated
+     * @deprecated since 2.3.0, this method will be removed in version 3.0.0 of this component.
+     *             {@see Serializable} as alternative
      */
     public function unserialize($data)
     {

--- a/src/Exception/SerializableException.php
+++ b/src/Exception/SerializableException.php
@@ -192,19 +192,31 @@ class SerializableException implements Serializable
         return $result;
     }
 
-    /**
-     * @see \Serializable
-     */
-    public function serialize()
+    public function __serialize()
     {
         return serialize($this->data);
     }
 
     /**
-     * @see \Serializable
+     * @see Serializable
+     * @deprecated
+     */
+    public function serialize()
+    {
+        return $this->__serialize();
+    }
+
+    public function __unserialize($data)
+    {
+        $this->data = unserialize($data);
+    }
+
+    /**
+     * @see Serializable
+     * @deprecated
      */
     public function unserialize($data)
     {
-        $this->data = unserialize($data);
+        $this->__unserialize($data);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Remove deprecated warnings when run phpunit and developer-tools itself.