### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "laminas/laminas-servicemanager": "^3.0.3",
         "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-view": "^2.13.1",
-        "laminas/laminas-zendframework-bridge": "^1.1",
         "symfony/var-dumper": "^5.0.1 || ^6.0"
     },
     "require-dev": {
@@ -69,7 +68,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-developer-tools": "^2.0.0"
+    "conflict": {
+        "zendframework/zend-developer-tools": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "131183b9482f3a423c326b6e70dd94e9",
+    "content-hash": "a8128aca3194daa4747efd5c910f9c07",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3736,5 +3736,5 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
