### PR TITLE
Fix access of undefined array index file when internally analyzing stack frames

### DIFF
--- a/src/EventLogging/EventContextProvider.php
+++ b/src/EventLogging/EventContextProvider.php
@@ -128,6 +128,10 @@ class EventContextProvider implements EventContextInterface
     {
         $backtrace = $this->getDebugBacktrace();
 
+        if (! isset($backtrace[4]['file'])) {
+            return '';
+        }
+
         if (file_exists($backtrace[4]['file'])) {
             return basename(dirname($backtrace[4]['file'])) . '/' . basename($backtrace[4]['file']);
         }

--- a/test/EventLogging/EventContextProviderTest.php
+++ b/test/EventLogging/EventContextProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\DeveloperTools\EventLogging;
+
+use Laminas\DeveloperTools\EventLogging\EventContextProvider;
+use PHPUnit\Framework\TestCase;
+
+class EventContextProviderTest extends TestCase
+{
+    public function testEventTriggerFileForInvokables()
+    {
+        $eventProviderClass = new class {
+            public function __invoke() {
+                return call_user_func([$this, 'get']);
+            }
+
+            private function get()
+            {
+                $eventProviderClass = new class {
+                    public function __invoke($invokableClass, int $maxLevel, int $level = 0)
+                    {
+                        if ($level < $maxLevel) {
+                            return $invokableClass($invokableClass, $maxLevel, ++$level);
+                        }
+
+                        return (new EventContextProvider())->getEventTriggerFile();
+                    }
+                };
+
+                return $eventProviderClass($eventProviderClass, 3);
+            }
+        };
+
+        $eventTriggerFile = $eventProviderClass();
+
+        self::assertSame(
+            '',
+            $eventTriggerFile,
+            'trigger file should be empty because user function calls do not refer to a file'
+        );
+    }
+}

--- a/test/EventLogging/EventContextProviderTest.php
+++ b/test/EventLogging/EventContextProviderTest.php
@@ -7,38 +7,43 @@ namespace LaminasTest\DeveloperTools\EventLogging;
 use Laminas\DeveloperTools\EventLogging\EventContextProvider;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
+
+/** @covers \Laminas\DeveloperTools\EventLogging\EventContextProvider */
 class EventContextProviderTest extends TestCase
 {
-    public function testEventTriggerFileForInvokables()
+    public function testEventTriggerFileDetectsEmptyFileLocationWhenStackFrameIsInPhpItself(): void
     {
-        $eventProviderClass = new class {
-            public function __invoke() {
-                return call_user_func([$this, 'get']);
-            }
-
-            private function get()
-            {
-                $eventProviderClass = new class {
-                    public function __invoke($invokableClass, int $maxLevel, int $level = 0)
-                    {
-                        if ($level < $maxLevel) {
-                            return $invokableClass($invokableClass, $maxLevel, ++$level);
-                        }
-
-                        return (new EventContextProvider())->getEventTriggerFile();
-                    }
-                };
-
-                return $eventProviderClass($eventProviderClass, 3);
-            }
-        };
-
-        $eventTriggerFile = $eventProviderClass();
-
         self::assertSame(
-            '',
-            $eventTriggerFile,
+            [
+                'stack frame on this file: EventLogging/EventContextProviderTest.php',
+                'stack frame in php core: ',
+                'stack frame on this file: EventLogging/EventContextProviderTest.php',
+            ],
+            // Important: `array_map()` needed here, as it produces a stack frame without "file" location
+            array_map(
+                [$this, 'callEventContextProviderWithStackTraceNestingLevelAndName'],
+                [
+                    'stack frame on this file',
+                    'stack frame in php core',
+                    'stack frame on this file',
+                ],
+                [
+                    3,
+                    4,
+                    5,
+                ]
+            ),
             'trigger file should be empty because user function calls do not refer to a file'
         );
+    }
+
+    private function callEventContextProviderWithStackTraceNestingLevelAndName(string $name, int $level): string
+    {
+        if ($level > 0) {
+            return $this->callEventContextProviderWithStackTraceNestingLevelAndName($name, $level - 1);
+        }
+
+        return $name . ': ' . (new EventContextProvider())->getEventTriggerFile();
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

When triggering events from within a controller plugin in laminas mvc the index is not a file because it is an invokable function. 

`
4 = {array} [5]
 function = "__invoke"
 class = "Application\Controller\Plugin\ForwardToPlugin"
 object = {Application\Controller\Plugin\ForwardToPlugin} [3]
 type = "->"
 args = {array} [2]
`

I just checked if the index exists and return an empty string.
