### PR TITLE
Fix psalm reported issues. Fix type errors in invalid serialize methods

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
   <file src="src/Collector/AbstractCollector.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>serialize</code>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingConstructor>
       <code>$data</code>
       <code>$data</code>
@@ -9,7 +13,7 @@
       <code>$data</code>
     </MissingConstructor>
     <MixedAssignment>
-      <code><![CDATA[$this->data]]></code>
+      <code>$data</code>
     </MixedAssignment>
   </file>
   <file src="src/Collector/CollectorInterface.php">
@@ -21,6 +25,10 @@
     <DocblockTypeContradiction>
       <code><![CDATA[! $application = $mvcEvent->getApplication()]]></code>
     </DocblockTypeContradiction>
+    <MethodSignatureMustProvideReturnType>
+      <code>serialize</code>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingReturnType>
       <code>collect</code>
     </MissingReturnType>
@@ -28,21 +36,14 @@
       <code><![CDATA[$serviceLocator->get('ApplicationConfig')]]></code>
       <code><![CDATA[$serviceLocator->get('config')]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$data['applicationConfig']]]></code>
-      <code><![CDATA[$data['config']]]></code>
-    </MixedArrayAccess>
     <MixedArrayOffset>
       <code>$serializable[$key]</code>
       <code>$serializable[$key]</code>
       <code>$serializable[$key]</code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code>$data</code>
       <code>$key</code>
       <code>$serializable[$key]</code>
-      <code><![CDATA[$this->applicationConfig]]></code>
-      <code><![CDATA[$this->config]]></code>
       <code>$unserialized[$key]</code>
       <code>$value</code>
       <code>$value</code>
@@ -58,21 +59,12 @@
     <PossiblyInvalidArgument>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyUnusedMethod>
-      <code>getApplicationConfig</code>
-      <code>getConfig</code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="src/Collector/DbCollector.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[count($this->profiler->getQueryProfiles($mode))]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>self</code>
-    </InvalidReturnType>
-    <MissingConstructor>
-      <code>$profiler</code>
-    </MissingConstructor>
+    <MethodSignatureMustProvideReturnType>
+      <code>serialize</code>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
     <MissingReturnType>
       <code>collect</code>
     </MissingReturnType>
@@ -81,7 +73,6 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$query</code>
-      <code><![CDATA[$this->profiler]]></code>
       <code>$time</code>
     </MixedAssignment>
     <MixedInferredReturnType>
@@ -97,6 +88,9 @@
     <MixedReturnStatement>
       <code>$time</code>
     </MixedReturnStatement>
+    <PossiblyNullReference>
+      <code>getQueryProfiles</code>
+    </PossiblyNullReference>
     <PossiblyUnusedMethod>
       <code>getProfiler</code>
       <code>getQueryTime</code>
@@ -106,17 +100,15 @@
     <PossiblyUnusedParam>
       <code>$profiler</code>
     </PossiblyUnusedParam>
-    <RedundantPropertyInitializationCheck>
-      <code><![CDATA[isset($this->profiler)]]></code>
-    </RedundantPropertyInitializationCheck>
     <UndefinedClass>
+      <code>Profiler</code>
       <code>Profiler</code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->profiler]]></code>
       <code><![CDATA[$this->profiler]]></code>
-      <code>Profiler</code>
-      <code>Profiler</code>
+      <code>null|Profiler</code>
+      <code>null|Profiler</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Collector/EventCollectorInterface.php">
@@ -257,7 +249,6 @@
       <code>collect</code>
     </MissingReturnType>
     <MixedArgument>
-      <code>$child</code>
       <code>$controller</code>
       <code>$controller</code>
       <code><![CDATA[$this->data['action']]]></code>
@@ -266,7 +257,6 @@
       <code>$views[]</code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code>$child</code>
       <code>$controller</code>
       <code>$var</code>
     </MixedAssignment>
@@ -406,6 +396,10 @@
     </UnusedClass>
   </file>
   <file src="src/Exception/SerializableException.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>serialize</code>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedArgument>
       <code><![CDATA[$entry['args']]]></code>
       <code><![CDATA[$entry['class']]]></code>
@@ -734,6 +728,9 @@
       <code>setProfiler</code>
       <code>setToolbar</code>
     </MissingReturnType>
+    <MissingTemplateParam>
+      <code>Options</code>
+    </MissingTemplateParam>
     <MixedArgument>
       <code><![CDATA[$options['collectors']]]></code>
       <code><![CDATA[$options['identifiers']]]></code>
@@ -741,6 +738,9 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$options</code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$this->events['collectors'][$name]]]></code>
       <code><![CDATA[$this->events['identifiers'][$name]]]></code>
@@ -796,9 +796,6 @@
     <MixedStringOffsetAssignment>
       <code><![CDATA[$this->toolbar[$key][$collector]]]></code>
     </MixedStringOffsetAssignment>
-    <PossiblyInvalidArgument>
-      <code>$options</code>
-    </PossiblyInvalidArgument>
     <PossiblyUnusedMethod>
       <code>canFlushEarly</code>
       <code>eventCollectionEnabled</code>
@@ -807,10 +804,6 @@
       <code>setEvents</code>
       <code>setProfiler</code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedParam>
-      <code>$options</code>
-      <code>$report</code>
-    </PossiblyUnusedParam>
     <TypeDoesNotContainType>
       <code>is_array($options)</code>
       <code>is_array($options)</code>
@@ -825,9 +818,6 @@
       <code>TimeCollector</code>
       <code>TimeCollector</code>
     </UndefinedClass>
-    <UndefinedDocblockClass>
-      <code>array|Traversable|null</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Profiler.php">
     <ImplementedReturnTypeMismatch>

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -6,6 +6,8 @@ namespace Laminas\DeveloperTools\Collector;
 
 use Serializable;
 
+use function assert;
+use function is_array;
 use function serialize;
 use function unserialize;
 
@@ -22,11 +24,11 @@ abstract class AbstractCollector implements CollectorInterface, Serializable
     protected $data;
 
     /**
-     * @return string
+     * @return array
      */
     public function __serialize()
     {
-        return serialize($this->data);
+        return ['data' => $this->data];
     }
 
     /**
@@ -37,16 +39,17 @@ abstract class AbstractCollector implements CollectorInterface, Serializable
      */
     public function serialize()
     {
-        return $this->__serialize();
+        return serialize($this->__serialize());
     }
 
     /**
-     * @param string $data
+     * @param array $data
      * @return void
      */
     public function __unserialize($data)
     {
-        $this->data = unserialize($data);
+        assert(isset($data['data']) && is_array($data['data']));
+        $this->data = $data['data'];
     }
 
     /**
@@ -57,6 +60,8 @@ abstract class AbstractCollector implements CollectorInterface, Serializable
      */
     public function unserialize($data)
     {
+        $data = unserialize($data);
+        assert(is_array($data));
         $this->__unserialize($data);
     }
 }

--- a/src/Collector/ConfigCollector.php
+++ b/src/Collector/ConfigCollector.php
@@ -11,6 +11,8 @@ use Laminas\Stdlib\ArrayUtils;
 use Serializable;
 use Traversable;
 
+use function array_key_exists;
+use function assert;
 use function is_array;
 use function serialize;
 use function unserialize;
@@ -82,11 +84,11 @@ class ConfigCollector implements CollectorInterface, Serializable
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function __serialize()
     {
-        return serialize(['config' => $this->config, 'applicationConfig' => $this->applicationConfig]);
+        return ['config' => $this->config, 'applicationConfig' => $this->applicationConfig];
     }
 
     /**
@@ -97,16 +99,19 @@ class ConfigCollector implements CollectorInterface, Serializable
      */
     public function serialize()
     {
-        return $this->__serialize();
+        return serialize($this->__serialize());
     }
 
     /**
-     * @param string $serialized
+     * @param array $data
      * @return void
      */
-    public function __unserialize($serialized)
+    public function __unserialize($data)
     {
-        $data                    = unserialize($serialized);
+        assert(array_key_exists('config', $data));
+        assert($data['config'] === null || is_array($data['config']));
+        assert(array_key_exists('applicationConfig', $data));
+        assert($data['applicationConfig'] === null || is_array($data['applicationConfig']));
         $this->config            = $data['config'];
         $this->applicationConfig = $data['applicationConfig'];
     }
@@ -119,7 +124,9 @@ class ConfigCollector implements CollectorInterface, Serializable
      */
     public function unserialize($serialized)
     {
-        $this->__unserialize($serialized);
+        $data = unserialize($serialized);
+        assert(is_array($data));
+        $this->__unserialize($data);
     }
 
     /**

--- a/src/Options.php
+++ b/src/Options.php
@@ -6,6 +6,7 @@ namespace Laminas\DeveloperTools;
 
 use Laminas\Stdlib\AbstractOptions;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
+use Traversable;
 
 use function gettype;
 use function is_array;

--- a/test/Collector/ConfigCollectorTest.php
+++ b/test/Collector/ConfigCollectorTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace LaminasTest\DeveloperTools\Collector;
 
 use Laminas\DeveloperTools\Collector\ConfigCollector;
-use Laminas\Mvc;
-use Laminas\ServiceManager;
+use Laminas\Mvc\Application;
+use Laminas\Mvc\MvcEvent;
+use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+
+use function serialize;
+use function unserialize;
 
 class ConfigCollectorTest extends TestCase
 {
@@ -15,22 +19,66 @@ class ConfigCollectorTest extends TestCase
     {
         $collector = new ConfigCollector();
 
-        $application    = $this->getMockBuilder(Mvc\Application::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $serviceManager = $this->getMockBuilder(ServiceManager\ServiceManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $config            = ['main' => 'config'];
+        $applicationConfig = ['main' => 'config'];
 
+        $serviceManager = new ServiceManager([
+            'services' => [
+                'config'            => $config,
+                'ApplicationConfig' => $applicationConfig,
+            ],
+        ]);
+
+        $application = $this->getMockBuilder(Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $application
             ->expects($this->once())
             ->method("getServiceManager")
             ->willReturn($serviceManager);
-        $mvcEvent = $this->getMockBuilder(Mvc\MvcEvent::class)
+        $mvcEvent = $this->getMockBuilder(MvcEvent::class)
             ->getMock();
-
         $mvcEvent->method("getApplication")->willReturn($application);
 
         $collector->collect($mvcEvent);
+
+        self::assertEqualsCanonicalizing($config, $collector->getConfig());
+        self::assertEqualsCanonicalizing($applicationConfig, $collector->getApplicationConfig());
+    }
+
+    public function testSerialize(): void
+    {
+        $collector = new ConfigCollector();
+
+        $config            = ['main' => 'config'];
+        $applicationConfig = ['main' => 'config'];
+
+        $serviceManager = new ServiceManager([
+            'services' => [
+                'config'            => $config,
+                'ApplicationConfig' => $applicationConfig,
+            ],
+        ]);
+
+        $application = $this->getMockBuilder(Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $application
+            ->expects($this->once())
+            ->method("getServiceManager")
+            ->willReturn($serviceManager);
+        $mvcEvent = $this->getMockBuilder(MvcEvent::class)
+            ->getMock();
+        $mvcEvent->method("getApplication")->willReturn($application);
+
+        $collector->collect($mvcEvent);
+
+        $serialized   = serialize($collector);
+        $unserialized = unserialize($serialized);
+
+        self::assertInstanceOf(ConfigCollector::class, $unserialized);
+
+        self::assertEqualsCanonicalizing($config, $collector->getConfig());
+        self::assertEqualsCanonicalizing($applicationConfig, $collector->getApplicationConfig());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

I am not sure what use the serialization has for collectors. I do not think anyone actually ever used that.

Tests are nearly non-existent. Bjy db profiler was not ported to laminas and archived since 2021. Mail collector implementation is `// todo`.

At the current quality this package is out to be abandoned imo.